### PR TITLE
Fix command example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Install by running `npm i -g source-map-unpacker`
 # Usage
 
 ```
-Usage: unpack [options]
+Usage: source-map-unpacker [options]
 
 Options:
   -p, --path <p>    input map file


### PR DESCRIPTION
Just wanted to issue a quick PR since while this installed and worked on my system (Windows 10) it setup shortcuts to the command `source-map-unpacker` and not `unpack`. 

![image](https://user-images.githubusercontent.com/4269377/122490474-f1943c80-cf96-11eb-91ea-7f5f2520b4a7.png)
