### PR TITLE
fix: use unpack instead of source-map-unpacker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "source-map-unpacker",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "",
   "main": "unmap.js",
-  "bin": "unmap.js",
+  "bin": {
+    "unpack": "unmap.js"
+  },
   "scripts": {
     "test": "node . -p test/gistfile1.txt  -o out"
   },


### PR DESCRIPTION
if no bin name is set it defaults to the package name so you have to type source-map-unpacker but in the readme its unpack

docs: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#bin